### PR TITLE
Move plugin install to container start

### DIFF
--- a/Dockerfile-kong
+++ b/Dockerfile-kong
@@ -8,7 +8,6 @@ USER root
 ADD https://raw.githubusercontent.com/eficode/wait-for/v2.2.1/wait-for /usr/local/bin/wait-for
 RUN chmod 755 /usr/local/bin/wait-for
 
-RUN luarocks install kong-plugin-ping-auth
 ENV KONG_PLUGINS=bundled,ping-auth
 
 ENV KONG_PROXY_LISTEN="0.0.0.0:8443 ssl reuseport backlog=16384"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - ${KONG_ADMIN_API_PORT:-8001}:${KONG_ADMIN_API_PORT:-8001}
       - ${KONG_ADMIN_GUI_PORT:-8002}:8002
       - ${KONG_ENGINE_HTTPS_PORT:-8443}:8443
-    command: wait-for -t 60 database:5432 -- sh -c "kong migrations bootstrap && kong start --run-migrations"
+    command: wait-for -t 60 database:5432 -- sh -c "luarocks install kong-plugin-ping-auth && kong migrations bootstrap && kong start --run-migrations"
   kong-config:
     container_name: p1az-kong-config
     image: curlimages/curl


### PR DESCRIPTION
This fixes an issue where customers who had run through the tutorial once would, on future run-throughs continue to use the older version of the Kong plugin that had been cached during the first Docker build.