### PR TITLE
Upgrade to qualified version on new image

### DIFF
--- a/Dockerfile-kong
+++ b/Dockerfile-kong
@@ -1,4 +1,4 @@
-FROM kong/kong-gateway:3.4-ubuntu
+FROM kong/kong-gateway:3.4.1.1-ubuntu
 
 USER root
 
@@ -12,7 +12,8 @@ RUN apt-get update && \
 ADD https://raw.githubusercontent.com/eficode/wait-for/v2.2.3/wait-for /usr/local/bin/wait-for
 RUN chmod 755 /usr/local/bin/wait-for
 
-RUN luarocks install kong-plugin-ping-auth 1.2.0-1
+RUN curl -LO https://luarocks.org/manifests/pingidentity/kong-plugin-ping-auth-1.2.0-1.rockspec
+RUN luarocks install kong-plugin-ping-auth-1.2.0-1.rockspec
 
 ENV KONG_PLUGINS=bundled,ping-auth
 

--- a/Dockerfile-kong
+++ b/Dockerfile-kong
@@ -5,7 +5,7 @@ USER root
 #COPY license.json /etc/kong/license.json
 
 RUN apt-get update && \
-    apt-get install -y netcat unzip curl git && \
+    apt-get install --no-install-recommends -y ca-certificates netcat unzip curl git && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile-kong
+++ b/Dockerfile-kong
@@ -1,12 +1,18 @@
-FROM kong/kong-gateway:2.7.0.0-alpine
-# FROM kong/kong-gateway:2.5.1.2-alpine
+FROM kong/kong-gateway:3.4-ubuntu
 
 USER root
 
 #COPY license.json /etc/kong/license.json
 
-ADD https://raw.githubusercontent.com/eficode/wait-for/v2.2.1/wait-for /usr/local/bin/wait-for
+RUN apt-get update && \
+    apt-get install -y netcat unzip curl git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+ADD https://raw.githubusercontent.com/eficode/wait-for/v2.2.3/wait-for /usr/local/bin/wait-for
 RUN chmod 755 /usr/local/bin/wait-for
+
+RUN luarocks install kong-plugin-ping-auth 1.2.0-1
 
 ENV KONG_PLUGINS=bundled,ping-auth
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - ${KONG_ADMIN_API_PORT:-8001}:${KONG_ADMIN_API_PORT:-8001}
       - ${KONG_ADMIN_GUI_PORT:-8002}:8002
       - ${KONG_ENGINE_HTTPS_PORT:-8443}:8443
-    command: wait-for -t 60 database:5432 -- sh -c "luarocks install kong-plugin-ping-auth 1.1.0-1 && kong migrations bootstrap && kong start --run-migrations"
+    command: wait-for -t 60 database:5432 -- sh -c "kong migrations bootstrap && kong start --run-migrations"
   kong-config:
     container_name: p1az-kong-config
     image: curlimages/curl


### PR DESCRIPTION
## Changes
- Change to Ubuntu image that supports multi-architecture (fixes PAZ-18809, PAZ-17910)
- Pin to versions that we most recently qualified (fixes PAZ-17929)
- Direct rockspec download is a workaround for https://support.konghq.com/support/s/article/LuaRocks-Error-main-function-has-more-than-65536-constants